### PR TITLE
Add missing context required by Typst since 0.12.0

### DIFF
--- a/recipe.typ
+++ b/recipe.typ
@@ -129,7 +129,7 @@
   steps: [],
   remarks: [],
   pairings: [],
-) = {
+) = context {
   show heading.where(
     level: 2
   ): it => text(


### PR DESCRIPTION
The example does not compile with Typst 0.12.0 and higher as they require a context.